### PR TITLE
Fix slack agent mentioning

### DIFF
--- a/server/lib/ai/respond-to-message.ts
+++ b/server/lib/ai/respond-to-message.ts
@@ -64,7 +64,7 @@ export const respondToMessage = async ({
       - After fetching context, answer clearly and helpfully.
       - Suggest next steps if needed; avoid unnecessary clarifying questions if tools can answer.
       - Slack markdown does not support language tags in code blocks.
-      - If your response includes a user's id like U0931KUHGC8, you must tag them. You cannot respond with just the id. You must use the @user_id syntax.
+      - If your response includes a user's id like U0931KUHGC8, you must tag them. You cannot respond with just the id. You must use the <@user_id> syntax.
 
       Message received
         │


### PR DESCRIPTION
H/T @malewis5 on the solution
https://api.slack.com/reference/surfaces/formatting#mentioning-users

new docs
https://docs.slack.dev/messaging/formatting-message-text/#mentioning-users
https://docs.slack.dev/changelog/2017-09-the-one-about-usernames/#mentioning-users-in-messages