### PR TITLE
fix(tunnel): update all slash commands URLs, not just first one

### DIFF
--- a/scripts/dev.tunnel.ts
+++ b/scripts/dev.tunnel.ts
@@ -98,7 +98,10 @@ interface SlackManifest {
 }
 
 const updateManifestUrls = (manifest: SlackManifest, newUrl: string): void => {
-  manifest.features.slash_commands[0].url = newUrl;
+  // Update all slash commands
+  manifest.features.slash_commands.forEach(command => {
+    command.url = newUrl;
+  });
   manifest.settings.event_subscriptions.request_url = newUrl;
   manifest.settings.interactivity.request_url = newUrl;
 };


### PR DESCRIPTION
When multiple slash commands exist, the tunnel script was only updating the first command's URL, causing dispatch failures for additional commands. Now updates all slash commands to use the current ngrok tunnel URL.